### PR TITLE
Handle non-numeric channel labels (e.g. 'LED') in OME metadata

### DIFF
--- a/snouty_folder/snouty_folder.py
+++ b/snouty_folder/snouty_folder.py
@@ -538,14 +538,21 @@ class SnoutyFolder:
         """
         channel_ome = []
         for ch_num, channel in enumerate(self.channels):
-            channel_ome.append(
-                model.Channel(
-                    id=f"Channel:{ch_num}",
-                    name=str(ch_num),
-                    emission_wavelength=channel,
-                    samples_per_pixel=1,
-                )
+            kwargs = dict(
+                id=f"Channel:{ch_num}",
+                name=str(channel),
+                samples_per_pixel=1,
             )
+            try:
+                kwargs["emission_wavelength"] = float(channel)
+                kwargs["illumination_type"] = model.Channel_IlluminationType.EPIFLUORESCENCE
+                kwargs["acquisition_mode"] = model.Channel_AcquisitionMode.SPIM
+                kwargs["contrast_method"] = model.Channel_ContrastMethod.FLUORESCENCE
+            except (TypeError, ValueError):
+                kwargs["illumination_type"] = model.Channel_IlluminationType.TRANSMITTED
+                kwargs["acquisition_mode"] = model.Channel_AcquisitionMode.BRIGHT_FIELD
+                kwargs["contrast_method"] = model.Channel_ContrastMethod.BRIGHTFIELD
+            channel_ome.append(model.Channel(**kwargs))
         return channel_ome
     
     def _get_max_deshear_shift(self):


### PR DESCRIPTION
## Summary
- `_get_channel_ome` unconditionally passed each channel string to `Channel.emission_wavelength`, which pydantic validates as a float. Non-numeric labels like `'LED'` (brightfield acquisitions) raised `ValidationError`.
- Split the channel construction into two branches based on whether the label parses as a float:
  - **Fluorescence branch** (e.g. `'488'`): sets `emission_wavelength`, plus `illumination_type=Epifluorescence`, `acquisition_mode=SPIM`, `contrast_method=Fluorescence`.
  - **Brightfield branch** (e.g. `'LED'`): omits `emission_wavelength`, sets `illumination_type=Transmitted`, `acquisition_mode=BrightField`, `contrast_method=Brightfield`.
- Channel `name` now uses the label string (e.g. `"LED"`, `"488"`) instead of the numeric index, so downstream tools can identify the modality.

## Repro (before the fix)
Acquisition metadata with `channels_per_slice: ('LED', '488')` blew up in `write_traditional_ome_tif()`:
```
ValidationError: 1 validation error for Channel
emission_wavelength
  Input should be a valid number, unable to parse string as a number [input_value='LED']
```

## Test plan
- [x] Smoke-tested `_get_channel_ome` logic against `('LED', '488')` — both `Channel` objects construct cleanly with the expected enum values.
- [ ] Re-run `folder.write_traditional_ome_tif()` end-to-end on a mixed brightfield+fluorescence acquisition and confirm the resulting OME-TIFF opens correctly (e.g. Fiji/napari picks a grayscale LUT for the brightfield channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)